### PR TITLE
Create spinup-destroy.yml

### DIFF
--- a/.github/workflows/spinup-destroy.yml
+++ b/.github/workflows/spinup-destroy.yml
@@ -1,0 +1,67 @@
+name: Configure Azure environment
+
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  IMAGE_REGISTRY_URL: ghcr.io
+  AZURE_RESOURCE_GROUP: cd-with-actions
+  AZURE_APP_PLAN: actions-ttt-deployment
+  AZURE_LOCATION: '"East US"'
+  ###############################################
+  ### Replace <username> with GitHub username ###
+  ###############################################
+  AZURE_WEBAPP_NAME: echoview2-ttt-app
+
+jobs:
+  setup-up-azure-resources:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'spin up environment')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Create Azure resource group
+        if: success()
+        run: |
+          az group create --location ${{env.AZURE_LOCATION}} --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Create Azure app service plan
+        if: success()
+        run: |
+          az appservice plan create --resource-group ${{env.AZURE_RESOURCE_GROUP}} --name ${{env.AZURE_APP_PLAN}} --is-linux --sku F1 --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Create webapp resource
+        if: success()
+        run: |
+          az webapp create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --plan ${{ env.AZURE_APP_PLAN }} --name ${{ env.AZURE_WEBAPP_NAME }}  --deployment-container-image-name nginx --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+      - name: Configure webapp to use GHCR
+        if: success()
+        run: |
+          az webapp config container set --docker-custom-image-name nginx --docker-registry-server-password ${{secrets.CR_PAT}} --docker-registry-server-url https://${{env.IMAGE_REGISTRY_URL}} --docker-registry-server-user ${{github.actor}} --name ${{ env.AZURE_WEBAPP_NAME }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+
+  destroy-azure-resources:
+    runs-on: ubuntu-latest
+
+    if: contains(github.event.pull_request.labels.*.name, 'destroy environment')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Destroy Azure environment
+        if: success()
+        run: |
+          az group delete --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} --yes


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the setup and teardown of Azure resources for testing environments. The workflow is triggered by specific labels on pull requests and includes jobs for both resource creation and destruction.

### New GitHub Actions Workflow for Azure Resource Management:

* `.github/workflows/spinup-destroy.yml`: Added a workflow to manage Azure resources. It includes two jobs:
  1. **`setup-up-azure-resources`**: Creates an Azure resource group, app service plan, and web app, and configures the web app to use a container image from GitHub Container Registry (GHCR). This job is triggered when a pull request is labeled with "spin up environment."
  2. **`destroy-azure-resources`**: Deletes the Azure resource group to clean up resources. This job is triggered when a pull request is labeled with "destroy environment."